### PR TITLE
Add isAdmin middleware to restrict access to admin-only routes

### DIFF
--- a/server/controllers/contestCon.js
+++ b/server/controllers/contestCon.js
@@ -62,7 +62,7 @@ const manageViolations = async (req, res) => {
     } catch (error) {
         res.status(500).json({ message: 'Server error', error: error.message });
     }
-};No
+};
 
 module.exports = {
     startContest,

--- a/server/middlewares/isAdmin.js
+++ b/server/middlewares/isAdmin.js
@@ -1,0 +1,27 @@
+const User = require('../models/User'); 
+const isAdmin = async (req, res, next) => {
+  try {
+    const clerkUserId = req.auth?.userId;
+
+    if (!clerkUserId) {
+      return res.status(401).json({ message: 'Unauthorized: No Clerk user ID found' });
+    }
+
+    const user = await User.findOne({ clerkId: clerkUserId });
+
+    if (!user) {
+      return res.status(404).json({ message: 'User not found in database' });
+    }
+
+    if (user.role !== 'admin') {
+      return res.status(403).json({ message: 'Forbidden: Admin access only' });
+    }
+
+    next(); // User is verified admin → continue
+  } catch (error) {
+    console.error('isAdmin Middleware Error:', error);
+    res.status(500).json({ message: 'Internal Server Error' });
+  }
+};
+
+module.exports = isAdmin;

--- a/server/routes/AdminRoute.js
+++ b/server/routes/AdminRoute.js
@@ -1,0 +1,17 @@
+const express = require('express');
+const router = express.Router();
+
+const { requireAuth } = require('../middlewares/auth');
+const isAdmin = require('../middlewares/isAdmin');
+
+const { startContest, manageViolations } = require('../controllers/contestCon');
+
+
+router.use(requireAuth, isAdmin);
+
+router.post('/contests/:id/start', startContest);
+router.post('/contests/:id/violation', manageViolations);
+
+// Add more routes like create/update/delete contests/questions here
+
+module.exports = router;


### PR DESCRIPTION
### What this PR does

- Adds a reusable `isAdmin` middleware in `server/middlewares/isAdmin.js`
- Checks if the authenticated Clerk user has `role: 'admin'`
- Blocks unauthorized users with appropriate status codes
- Protects contest and question CRUD routes from misuse

### Linked Issue
Closes #9
