### PR TITLE
fix: fix code submission in submitCon

### DIFF
--- a/server/controllers/submitCon.js
+++ b/server/controllers/submitCon.js
@@ -73,7 +73,7 @@ const executeTestCases = async ({ question, code, language, testCases, judge0Id 
             const decodedCompileOutput = result.compile_output ? Buffer.from(result.compile_output, 'base64').toString('utf-8') : '';
 
             return {
-                testCase: tc._id || index + 1,
+                testCase: index + 1,
                 passed: isPassed,
                 input: tc.isVisible ? input : undefined, // Hide input if not visible
                 expectedOutput: tc.isVisible ? expectedOutput : undefined,
@@ -84,7 +84,7 @@ const executeTestCases = async ({ question, code, language, testCases, judge0Id 
             };
         } catch (err) {
             return {
-                testCase: tc._id || index + 1,
+                testCase: index + 1,
                 passed: false,
                 status: "System Error",
                 error: err.message,


### PR DESCRIPTION
### The issue:
The `testCase` field in the Submission schema expects a `Number`,  but we're passing `tc._id` which is an ObjectId.

### The fix:
replace `testCase: tc._id || index + 1,`  with `testCase: index + 1,` in submitCon.js line 76 and 87