### PR TITLE
 Port Configuration, MongoDB Install Resilience & DB Startup Guard

### DIFF
--- a/admin/src/cli/core/config.ts
+++ b/admin/src/cli/core/config.ts
@@ -1,3 +1,23 @@
-export const API_BASE = process.env.POMELO_API_URL ?? "http://127.0.0.1:8462";
+import { existsSync, readFileSync } from "fs";
+import { join } from "path";
+import YAML from "yaml";
+
 export const APP_ROOT = process.env.POMELO_ROOT ?? "/opt/pomelo";
 export const DEFAULT_DAEMON_BIN = `${APP_ROOT}/app/admin/bin/pomelod`;
+
+function resolveApiBase(): string {
+  if (process.env.POMELO_API_URL) return process.env.POMELO_API_URL;
+  try {
+    const configFile = join(APP_ROOT, "config", "config.yaml");
+    if (existsSync(configFile)) {
+      const cfg = YAML.parse(readFileSync(configFile, "utf8"));
+      const port = cfg?.ports?.admin;
+      if (port && Number.isInteger(Number(port))) {
+        return `http://127.0.0.1:${port}`;
+      }
+    }
+  } catch {}
+  return "http://127.0.0.1:8462";
+}
+
+export const API_BASE = resolveApiBase();

--- a/admin/src/daemon/services/db-check.ts
+++ b/admin/src/daemon/services/db-check.ts
@@ -1,0 +1,60 @@
+/**
+ * Validates that an external MongoDB URI is reachable via TCP before starting the stack.
+ * Only used when database.mode = "external" — internal mode launches Mongo via Docker Compose.
+ */
+export async function validateMongoConnection(uri: string): Promise<void> {
+  const { hostname, port: portStr } = parseMongoUri(uri);
+  const port = portStr ? parseInt(portStr, 10) : 27017;
+
+  await new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      reject(new Error(`Timed out connecting to MongoDB at ${hostname}:${port}`));
+    }, 3000);
+
+    Bun.connect({
+      hostname,
+      port,
+      socket: {
+        open(socket) {
+          clearTimeout(timeout);
+          socket.end();
+          resolve();
+        },
+        error(_socket, err) {
+          clearTimeout(timeout);
+          reject(err);
+        },
+        connectError(_socket, err) {
+          clearTimeout(timeout);
+          reject(err);
+        },
+        // Required by Bun socket type but unused here
+        data() {},
+        close() {},
+      },
+    }).catch((err) => {
+      clearTimeout(timeout);
+      reject(err);
+    });
+  });
+}
+
+function parseMongoUri(uri: string): { hostname: string; port: string | null } {
+  try {
+    // Strip mongodb:// or mongodb+srv:// prefix then grab host:port before /
+    const withoutScheme = uri.replace(/^mongodb(\+srv)?:\/\//, "");
+    // Remove credentials if present
+    const hostPart = withoutScheme.includes("@")
+      ? withoutScheme.split("@")[1]
+      : withoutScheme;
+    // Remove path/options
+    const hostAndPort = hostPart.split("/")[0].split("?")[0];
+    const lastColon = hostAndPort.lastIndexOf(":");
+    if (lastColon === -1) return { hostname: hostAndPort, port: null };
+    const hostname = hostAndPort.slice(0, lastColon);
+    const port = hostAndPort.slice(lastColon + 1);
+    return { hostname, port };
+  } catch {
+    return { hostname: "localhost", port: null };
+  }
+}

--- a/admin/src/daemon/web/api.ts
+++ b/admin/src/daemon/web/api.ts
@@ -1,13 +1,15 @@
+import { existsSync, readFileSync } from "fs";
 import YAML from "yaml";
 import { logsResponse, startCompose } from "../services/compose";
 import { ComposeCommand } from "../services/compose-command";
-import { getConfigSnapshot, updateConfig, validateConfig, parseConfigYaml, ensureConfigDefaults } from "../core/config";
+import { getConfigSnapshot, updateConfig, validateConfig, parseConfigYaml, ensureConfigDefaults, parseEnv } from "../core/config";
 import { getCurrentReleaseDir } from "../core/release";
 import { errorResponse, json, normalizeError, readJson } from "./http";
 import { getStatus, getStorageUsage } from "../services/status";
 import { startUninstall } from "../services/uninstall";
 import { createUser, deleteUser, listUsers, updateUser } from "../services/users";
 import { isOperationRunning, getOperationState, getLogBuffer, subscribeToLogs } from "../services/operations";
+import { validateMongoConnection } from "../services/db-check";
 import type { Paths } from "../core/types";
 
 /**
@@ -17,31 +19,38 @@ function determineRestartAction(
   paths: Paths,
   body: any,
   currentConfig: ReturnType<typeof getConfigSnapshot>,
-): "none" | "restart-all" | "reload-caddy" | "restart-caddy" | "restart-judge" {
+): "none" | "restart-all" | "reload-caddy" | "restart-caddy" | "restart-judge" | "restart-daemon" {
   const appEnvChanged = typeof body.appEnv === "string" && body.appEnv !== currentConfig.appEnv;
   const configYamlChanged = typeof body.configYaml === "string" && body.configYaml !== currentConfig.configYaml;
   const caddyfileChanged = typeof body.caddyfile === "string" && body.caddyfile !== currentConfig.caddyfile;
   const judge0Changed = typeof body.judge0 === "string" && body.judge0 !== currentConfig.judge0;
 
+  if (configYamlChanged) {
+    const oldCfg = parseConfigYaml(paths) || {};
+    let newCfg: any = {};
+    try {
+      newCfg = YAML.parse(body.configYaml) || {};
+    } catch {}
+
+    // Admin port change — daemon must restart to bind to the new port
+    const oldAdminPort = oldCfg.ports?.admin ?? 8462;
+    const newAdminPort = newCfg.ports?.admin ?? 8462;
+    if (oldAdminPort !== newAdminPort) {
+      return "restart-daemon";
+    }
+
+    const oldHttpPort = oldCfg.ports?.caddyHttp ?? 80;
+    const oldHttpsPort = oldCfg.ports?.caddyHttps ?? 443;
+    const newHttpPort = newCfg.ports?.caddyHttp ?? 80;
+    const newHttpsPort = newCfg.ports?.caddyHttps ?? 443;
+
+    if (oldHttpPort !== newHttpPort || oldHttpsPort !== newHttpsPort) {
+      return "restart-all";
+    }
+  }
+
   // If core app config or env changed, full restart is needed
   if (appEnvChanged || configYamlChanged) {
-    // Check if ports changed in configYaml — Caddy needs a container restart for port changes
-    if (configYamlChanged) {
-      const oldCfg = parseConfigYaml(paths) || {};
-      let newCfg: any = {};
-      try {
-        newCfg = YAML.parse(body.configYaml) || {};
-      } catch {}
-
-      const oldHttpPort = oldCfg.ports?.caddyHttp ?? 80;
-      const oldHttpsPort = oldCfg.ports?.caddyHttps ?? 443;
-      const newHttpPort = newCfg.ports?.caddyHttp ?? 80;
-      const newHttpsPort = newCfg.ports?.caddyHttps ?? 443;
-
-      if (oldHttpPort !== newHttpPort || oldHttpsPort !== newHttpsPort) {
-        return "restart-all"; // Port changes need full container restart
-      }
-    }
     return "restart-all";
   }
 
@@ -120,6 +129,25 @@ export function createApiHandler(paths: Paths) {
 
       if (method === "POST" && url.pathname === "/api/start") {
         ensureConfigDefaults(paths, getCurrentReleaseDir(paths));
+
+        // For external DB mode, validate MongoDB is reachable before starting the stack
+        const cfgYaml = parseConfigYaml(paths) || {};
+        if (cfgYaml.infrastructure?.database?.mode === "external") {
+          const appEnvText = existsSync(paths.envFile) ? readFileSync(paths.envFile, "utf8") : "";
+          const mongoUri = parseEnv(appEnvText)["MONGODB_URI"];
+          if (mongoUri) {
+            try {
+              await validateMongoConnection(mongoUri);
+            } catch (err: any) {
+              return errorResponse(
+                `Cannot connect to external MongoDB at ${mongoUri}. Check MONGODB_URI in app.env. (${err.message})`,
+                1,
+                400,
+              );
+            }
+          }
+        }
+
         const compose = ComposeCommand.from(paths);
         await startCompose(paths, "start", [
           { label: "Stopping existing containers...", descriptor: ComposeCommand.forTeardown(paths).downKeepVolumes() },
@@ -177,6 +205,11 @@ export function createApiHandler(paths: Paths) {
         const restartAction = determineRestartAction(paths, body, currentConfig);
 
         updateConfig(paths, body);
+
+        if (restartAction === "restart-daemon") {
+          // Respond first, then exit — systemd Restart=always will bring daemon back on new port
+          setTimeout(() => process.exit(0), 500);
+        }
 
         return json({ status: "ok", data: { saved: true, restartAction } });
       }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -206,48 +206,73 @@ fi
 # --- 1.5. Port Collision Checks ---
 log_step "Checking port availability"
 
-BLOCKED_PORTS=()
-
-check_port() {
+# Returns 0 if port is in use, 1 if free
+port_in_use() {
   local port=$1
-  local desc=$2
-  local in_use=false
-
   if command -v ss &>/dev/null; then
-    if ss -tuln | awk '{print $5}' | grep -E -q ":${port}$"; then
-      in_use=true
-    fi
+    ss -tuln | awk '{print $5}' | grep -E -q ":${port}$"
   elif command -v netstat &>/dev/null; then
-    if netstat -tuln | awk '{print $4}' | grep -E -q ":${port}$"; then
-      in_use=true
-    fi
+    netstat -tuln | awk '{print $4}' | grep -E -q ":${port}$"
   else
-    if (bash -c "timeout 1 echo >/dev/tcp/127.0.0.1/${port}" 2>/dev/null); then
-      in_use=true
-    fi
-  fi
-
-  if [[ "$in_use" == true ]]; then
-    BLOCKED_PORTS+=("${port} (${desc})")
+    bash -c "timeout 1 echo >/dev/tcp/127.0.0.1/${port}" 2>/dev/null
   fi
 }
 
-check_port 80 "HTTP / Caddy"
-check_port 443 "HTTPS / Caddy"
-check_port 27017 "MongoDB"
-check_port 8462 "Pomelo Admin UI"
+# Prompt user to choose an alternative port when the default is taken.
+# Sets the named variable (3rd arg) to the chosen port.
+# All interactive output goes to stderr so callers can safely use the result.
+resolve_port() {
+  local default_port=$1
+  local desc=$2
+  local -n _result_ref=$3
+  local chosen=$default_port
 
-if [[ ${#BLOCKED_PORTS[@]} -gt 0 ]]; then
-  echo ""
-  log_error "The following required ports are currently in use:"
-  for blocked in "${BLOCKED_PORTS[@]}"; do
-    echo -e "    ${YELLOW}• Port $blocked${NC}"
-  done
-  echo ""
-  log_error "Please free these ports before proceeding with the installation."
-  exit 1
+  if port_in_use "$default_port"; then
+    log_warn "Port ${default_port} (${desc}) is already in use."
+    while true; do
+      prompt "Enter an alternative port for ${desc} (or press Enter to keep ${default_port} and resolve it yourself):"
+      read -r alt_port
+      if [[ -z "$alt_port" ]]; then
+        chosen=$default_port
+        break
+      fi
+      if ! [[ "$alt_port" =~ ^[0-9]+$ ]] || [[ "$alt_port" -lt 1 ]] || [[ "$alt_port" -gt 65535 ]]; then
+        log_error "Invalid port number. Enter a value between 1 and 65535."
+        continue
+      fi
+      if port_in_use "$alt_port"; then
+        log_error "Port $alt_port is also in use. Try another."
+        continue
+      fi
+      chosen=$alt_port
+      break
+    done
+    if [[ "$chosen" != "$default_port" ]]; then
+      log_success "Using port ${chosen} for ${desc}."
+    else
+      log_warn "Keeping port ${default_port} for ${desc} — make sure it is free before starting."
+    fi
+  else
+    log_success "Port ${default_port} (${desc}) is available."
+  fi
+  _result_ref=$chosen
+}
+
+resolve_port 80   "HTTP / Caddy"    CADDY_HTTP_PORT
+resolve_port 443  "HTTPS / Caddy"   CADDY_HTTPS_PORT
+resolve_port 8462 "Pomelo Admin UI" ADMIN_PORT
+
+# --- MongoDB port: non-blocking, auto-configure external mode if taken ---
+MONGO_DB_MODE="internal"
+MONGO_URI="mongodb://mongo:27017/pomelo"
+
+if port_in_use 27017; then
+  log_warn "Port 27017 (MongoDB) is already in use."
+  log_warn "Pomelo will use ${BOLD}external${NC} database mode, connecting to the existing MongoDB at localhost:27017."
+  MONGO_DB_MODE="external"
+  MONGO_URI="mongodb://localhost:27017/pomelo"
 else
-  log_success "All required ports are available."
+  log_success "Port 27017 (MongoDB) is available."
 fi
 
 # --- 2. Permission Check ---
@@ -497,11 +522,11 @@ log_step "Initializing configuration"
 
 if [[ ! -s "$APP_ROOT/config/app.env" ]]; then
   log_info "Generating secure environment variables..."
-  
+
   gen_secret() {
     openssl rand -hex 32
   }
-  
+
   AUTH_SECRET=$(gen_secret)
   POSTGRES_PASSWORD=$(gen_secret)
   REDIS_PASSWORD=$(gen_secret)
@@ -509,7 +534,7 @@ if [[ ! -s "$APP_ROOT/config/app.env" ]]; then
   cat > "$APP_ROOT/config/app.env" <<EOF
 # --- SECRETS & URIS ---
 AUTH_SECRET=${AUTH_SECRET}
-MONGODB_URI=mongodb://mongo:27017/pomelo
+MONGODB_URI=${MONGO_URI}
 JUDGE0_URL=http://judge0-server:2358
 POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
 REDIS_PASSWORD=${REDIS_PASSWORD}
@@ -530,13 +555,13 @@ app:
   protocol: "http"
 
 ports:
-  admin: 8462
-  caddyHttp: 80
-  caddyHttps: 443
+  admin: ${ADMIN_PORT}
+  caddyHttp: ${CADDY_HTTP_PORT}
+  caddyHttps: ${CADDY_HTTPS_PORT}
 
 infrastructure:
   database:
-    mode: "internal"  # 'internal' or 'external'
+    mode: "${MONGO_DB_MODE}"  # 'internal' or 'external'
   judge0:
     mode: "internal"  # 'internal' or 'external'
 YAML_EOF
@@ -568,7 +593,7 @@ echo -e "  ${BOLD}Daemon:${NC}         systemd (${GREEN}persistent${NC})"
 else
 echo -e "  ${BOLD}Daemon:${NC}         background process (${YELLOW}non-persistent${NC})"
 fi
-echo -e "  ${BOLD}Admin UI:${NC}       ${CYAN}http://127.0.0.1:8462${NC}"
+echo -e "  ${BOLD}Admin UI:${NC}       ${CYAN}http://127.0.0.1:${ADMIN_PORT}${NC}"
 echo -e "  ${BOLD}CLI:${NC}            ${DIM}pomelo --help${NC}"
 echo ""
 echo -e "  ${BOLD}Quick Start:${NC}"

--- a/server/index.js
+++ b/server/index.js
@@ -16,9 +16,6 @@ const authRoutes = require("./routes/authRoutes");
 
 const port = process.env.PORT || 8080;
 
-// Connect to Database
-connectDB();
-
 // Initialize Cron Jobs (Removed: using lazy/computed status)
 // const initCron = require("./services/cron");
 // initCron();
@@ -49,9 +46,12 @@ app.use("/api/test", contestRoutes);
 const submitRoutes = require("./routes/submitRoutes");
 app.use("/api/submit", submitRoutes);
 
-app.listen(port, () => {
-  console.log(`Server running on port ${port}`);
-});
+(async () => {
+  await connectDB();
+  app.listen(port, () => {
+    console.log(`Server running on port ${port}`);
+  });
+})();
 
 // Global error handler — must be last
 app.use((err, req, res, next) => {


### PR DESCRIPTION
- Configurable ports at install time — install.sh no longer hard-fails when default ports (80, 443, 8462) are in use. It prompts the user to choose an alternative and writes the chosen values into config.yaml. The completion banner reflects the actual admin port.
- MongoDB port is non-blocking — Port 27017 being in use no longer aborts the install. Pomelo automatically switches to external database mode and sets MONGODB_URI to mongodb://localhost:27017/pomelo, connecting to the existing MongoDB on the host.
- CLI reads admin port from config.yaml — The pomelo CLI no longer hardcodes port 8462. It resolves the admin port from $POMELO_ROOT/config/config.yaml at startup, so it works correctly after any port change without needing POMELO_API_URL to be set manually.
- Daemon self-restarts on admin port change — When ports.admin is updated via the config UI, the daemon detects the change, saves the config, and schedules a process.exit(0) after responding. systemd's Restart=always brings it back up on the new port.
- External MongoDB validated before start — When infrastructure.database.mode is external, pomelo start now does a TCP reachability check against MONGODB_URI before launching Docker Compose. An unreachable MongoDB returns a clear error instead of letting containers spin up and crash.
- Server blocks on MongoDB before listening — server/index.js now awaits connectDB() before calling app.listen(), ensuring the HTTP server never briefly accepts connections while the database is still connecting or unavailable.