### PR TITLE
fix: string array support and testcase UI improvements

### DIFF
--- a/client/components/admin/question/coding/test-case-card.tsx
+++ b/client/components/admin/question/coding/test-case-card.tsx
@@ -151,8 +151,11 @@ export default function TestCaseCard() {
                 });
 
                 const inputData: Record<string, any> = {};
-                inputVariables.forEach((v: {variable: string}) => {
-                    inputData[v.variable] = rowData[v.variable] || '';
+                inputVariables.forEach((v: {variable: string; type: string}) => {
+                    const raw = rowData[v.variable] || '';
+                    inputData[v.variable] = v.type.includes("_array")
+                        ? raw.split(',').map((s: string) => s.trim()).filter((s: string) => s !== '')
+                        : raw;
                 });
 
                 newTestCases.push({
@@ -410,7 +413,50 @@ export default function TestCaseCard() {
                                                             <FormItem>
                                                                 <FormLabel className="text-xs">{variable.variable} <span className="text-muted-foreground font-normal">({variable.type})</span></FormLabel>
                                                                 <FormControl>
-                                                                    <Input {...field} value={field.value ?? ""} placeholder={`Value for ${variable.variable}`} className="h-8 text-sm" />
+                                                                    {variable.type.includes("_array") ? (
+                                                                        <div className="space-y-1.5">
+                                                                            {(Array.isArray(field.value) ? field.value : []).map((elem: string, eIdx: number) => {
+                                                                                const arr: string[] = Array.isArray(field.value) ? field.value : [];
+                                                                                return (
+                                                                                    <div key={eIdx} className="flex gap-1.5">
+                                                                                        <Input
+                                                                                            value={elem}
+                                                                                            onChange={e => {
+                                                                                                const next = [...arr];
+                                                                                                next[eIdx] = e.target.value;
+                                                                                                field.onChange(next);
+                                                                                            }}
+                                                                                            className="h-8 text-sm flex-1"
+                                                                                            placeholder={`Element ${eIdx + 1}`}
+                                                                                        />
+                                                                                        <Button
+                                                                                            type="button"
+                                                                                            variant="ghost"
+                                                                                            size="icon"
+                                                                                            className="h-8 w-8 text-destructive"
+                                                                                            onClick={() => field.onChange(arr.filter((_, i) => i !== eIdx))}
+                                                                                        >
+                                                                                            <Trash2 className="h-3.5 w-3.5" />
+                                                                                        </Button>
+                                                                                    </div>
+                                                                                );
+                                                                            })}
+                                                                            <Button
+                                                                                type="button"
+                                                                                variant="outline"
+                                                                                size="sm"
+                                                                                className="w-full h-7 text-xs mt-1"
+                                                                                onClick={() => {
+                                                                                    const arr: string[] = Array.isArray(field.value) ? field.value : [];
+                                                                                    field.onChange([...arr, ""]);
+                                                                                }}
+                                                                            >
+                                                                                <Plus className="h-3 w-3 mr-1" /> Add Element
+                                                                            </Button>
+                                                                        </div>
+                                                                    ) : (
+                                                                        <Input {...field} value={field.value ?? ""} placeholder={`Value for ${variable.variable}`} className="h-8 text-sm" />
+                                                                    )}
                                                                 </FormControl>
                                                                 <FormMessage />
                                                             </FormItem>

--- a/client/components/attempt/code/test-case.tsx
+++ b/client/components/attempt/code/test-case.tsx
@@ -137,7 +137,9 @@ export default function TestCasePanel({
                       ? tc.passed
                         ? "bg-primary/10 text-primary border border-primary/20"
                         : "bg-destructive/10 text-destructive border border-destructive/20"
-                      : "bg-muted/50 hover:bg-muted text-muted-foreground border border-transparent"
+                      : tc.passed
+                        ? "bg-primary/5 text-primary/60 border border-primary/10 hover:bg-primary/10"
+                        : "bg-destructive/5 text-destructive/60 border border-destructive/10 hover:bg-destructive/10"
                   }`}
                 >
                   {tc.passed ? <CheckCircle2 className="w-3.5 h-3.5" /> : <XCircle className="w-3.5 h-3.5" />}

--- a/packages/code-gen/src/c/config.json
+++ b/packages/code-gen/src/c/config.json
@@ -26,6 +26,10 @@
     "float_array": {
       "reader": "scanf(\"%d\", &{var}_size); for(int i=0; i<{var}_size; i++) { scanf(\"%f\", &{var}[i]); }",
       "hint": "float*"
+    },
+    "string_array": {
+      "reader": "scanf(\"%d\", &{var}_size); for(int i=0; i<{var}_size; i++) { {var}[i] = (char*)malloc(256); scanf(\"%s\", {var}[i]); }",
+      "hint": "char**"
     }
   }
 }

--- a/packages/code-gen/src/java/config.json
+++ b/packages/code-gen/src/java/config.json
@@ -26,6 +26,10 @@
     "float_array": {
       "reader": "int {var}_size = scanner.nextInt(); float[] {var} = new float[{var}_size]; for(int i=0; i<{var}_size; i++) { {var}[i] = scanner.nextFloat(); }",
       "hint": "float[]"
+    },
+    "string_array": {
+      "reader": "int {var}_size = scanner.nextInt(); String[] {var} = new String[{var}_size]; for(int i=0; i<{var}_size; i++) { {var}[i] = scanner.next(); }",
+      "hint": "String[]"
     }
   }
 }

--- a/packages/code-gen/src/python/config.json
+++ b/packages/code-gen/src/python/config.json
@@ -26,6 +26,10 @@
     "float_array": {
       "reader": "[float(next(iterator)) for _ in range(int(next(iterator)))]",
       "hint": "list[float]"
+    },
+    "string_array": {
+      "reader": "[next(iterator) for _ in range(int(next(iterator)))]",
+      "hint": "list[str]"
     }
   }
 }


### PR DESCRIPTION
## Summary

- **Testcase tabs**: All tabs now immediately show green/red pass/fail coloring after running code — previously only the active tab was colored, requiring users to click each tab to check results
- **Array input editor**: Array-typed input variables (`int_array`, `float_array`, `string_array`) in the question admin now render an element-by-element editor with Add/Remove buttons, replacing the broken plain text box that coerced arrays to comma-joined strings
- **code-gen `string_array`**: Added `string_array` reader to all three language configs (Python, C, Java) — it was accepted as a valid type everywhere but had no reader, causing Python to read a single token and C/Java to generate no reader at all

## Changes

| File | What changed |
|---|---|
| `client/components/attempt/code/test-case.tsx` | Pass/fail color on all testcase tabs |
| `client/components/admin/question/coding/test-case-card.tsx` | Array input element editor + CSV import fix |
| `packages/code-gen/src/python/config.json` | Add `string_array` reader |
| `packages/code-gen/src/c/config.json` | Add `string_array` reader |
| `packages/code-gen/src/java/config.json` | Add `string_array` reader |

## Notes

- `packages/code-gen/dist/` is gitignored — run `npm run build` inside the package after pulling to regenerate before starting the server
- No DB migrations, schema changes, or serialization format changes required