### PR TITLE
fix: timezone-aware contest scheduling and display

### DIFF
--- a/client/actions/save-test.ts
+++ b/client/actions/save-test.ts
@@ -4,37 +4,11 @@ import { testSchema, TestSchema } from "@/types/test";
 import { revalidatePath } from "next/cache";
 import { fetchBackend } from "@/lib/fetch";
 
-function parseDuration(duration: string) {
-  const match = duration.trim().match(/^(\d{1,2}):(\d{2})\s*(AM|PM)$/i);
-  if (!match) {
-    throw new Error("End time must be in HH:MM AM/PM format");
-  }
-
-  const hours = Number(match[1]);
-  const minutes = Number(match[2]);
-  const period = match[3].toUpperCase();
-
-  if (hours < 1 || hours > 12 || minutes < 0 || minutes > 59) {
-    throw new Error("End time must be in HH:MM AM/PM format");
-  }
-
-  let normalizedHours = hours % 12;
-  if (period === "PM") {
-    normalizedHours += 12;
-  }
-
-  return {
-    hours: normalizedHours,
-    minutes,
-    seconds: 0,
-  };
-}
-
 export async function saveTest(_prevState: Record<string, unknown>, data: TestSchema) {
   try {
     const validatedData = testSchema.parse(data);
-    const { hours, minutes, seconds } = parseDuration(String(validatedData.duration));
     const startDate = new Date(validatedData.startsAt);
+    const endDate = new Date(validatedData.endsAt);
     const now = new Date();
     const bufferMs = 5 * 60 * 1000;
 
@@ -42,12 +16,8 @@ export async function saveTest(_prevState: Record<string, unknown>, data: TestSc
       throw new Error("Start time cannot be in the past");
     }
 
-    const endDate = new Date(startDate);
-
-    endDate.setHours(hours, minutes, seconds, 0);
-
     if (endDate <= startDate) {
-      endDate.setDate(endDate.getDate() + 1);
+      throw new Error("End time must be after start time");
     }
 
     const payload = {
@@ -55,7 +25,7 @@ export async function saveTest(_prevState: Record<string, unknown>, data: TestSc
       description: validatedData.description,
       duration: {
         start: validatedData.startsAt,
-        end: endDate.toISOString()
+        end: validatedData.endsAt,
       },
       problemIds: validatedData.problems,
       rules: validatedData.rules,

--- a/client/app/admin/tests/[id]/edit/page.tsx
+++ b/client/app/admin/tests/[id]/edit/page.tsx
@@ -2,7 +2,6 @@ import { notFound } from "next/navigation";
 import TestForm from "@/components/admin/test/test-form";
 import { db } from "@/lib/db";
 import { Problem } from "@/types/problem";
-import { formatTimeForDisplay } from "@/lib/date-utils";
 
 export const dynamic = "force-dynamic";
 
@@ -63,14 +62,12 @@ export default async function AdminTestEditPage({
 
   let testData = null;
   if (testDataRaw) {
-    const end = new Date(testDataRaw.endTime);
-    const endTimeStr = formatTimeForDisplay(end);
-
     testData = {
       ...testDataRaw,
       id: testDataRaw._id,
       startsAt: testDataRaw.startTime ? new Date(testDataRaw.startTime).toISOString() : '',
-      duration: endTimeStr,
+      endsAt: testDataRaw.endTime ? new Date(testDataRaw.endTime).toISOString() : '',
+      duration: '',
       problems: (testDataRaw.questions || []).map((q) => typeof q === 'string' ? q : (q._id || q.id || String(q))),
       rules: testDataRaw.rules || [],
       status: (testDataRaw.status || "waiting") as "waiting" | "ongoing" | "completed",

--- a/client/app/admin/tests/[id]/result/page.tsx
+++ b/client/app/admin/tests/[id]/result/page.tsx
@@ -19,7 +19,7 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import Link from "next/link";
 import { notFound } from "next/navigation";
-import { format } from "date-fns";
+import { LocalTime } from "@/components/ui/local-time";
 
 /* ---------- Types ---------- */
 interface Participant {
@@ -59,14 +59,6 @@ interface MongoSubmission {
     submittedAt: string;
 }
 
-function formatSubmittedAt(value: string) {
-    const date = new Date(value);
-    if (Number.isNaN(date.getTime())) {
-        return "Unknown";
-    }
-
-    return format(date, "MMM d, yyyy, h:mm a");
-}
 
 export default async function AdminTestResultPage({ params }: { params: Promise<{ id: string }> }) {
     const { id } = await params;
@@ -204,7 +196,7 @@ export default async function AdminTestResultPage({ params }: { params: Promise<
                                                     </div>
                                                 </TableCell>
                                                 <TableCell className="text-sm text-muted-foreground">
-                                                    {formatSubmittedAt(p.submittedAt)}
+                                                    <LocalTime iso={p.submittedAt} />
                                                 </TableCell>
                                                 <TableCell className="px-6">
                                                     <div className="flex items-center justify-end gap-2">

--- a/client/app/admin/tests/[id]/submissions/[userId]/page.tsx
+++ b/client/app/admin/tests/[id]/submissions/[userId]/page.tsx
@@ -1,6 +1,6 @@
 import { notFound } from "next/navigation";
 import Link from "next/link";
-import { format } from "date-fns";
+import { LocalTime } from "@/components/ui/local-time";
 import {
     ArrowLeft,
     CheckCircle2,
@@ -167,14 +167,6 @@ function mapSubmissionDetail(submissionItem: RawSubmissionItem): SubmissionDetai
     };
 }
 
-function formatSubmittedAt(value: string) {
-    const date = new Date(value);
-    if (Number.isNaN(date.getTime())) {
-        return "Unknown";
-    }
-
-    return format(date, "MMM d, yyyy, h:mm a");
-}
 
 function getSubmissionStatusVariant(status: SubmissionStatus): "default" | "destructive" | "secondary" {
     if (status === "PASSED" || status === "Accepted") {
@@ -260,7 +252,7 @@ export default async function SubmissionDetailPage({
                 <div className="grid gap-6 md:grid-cols-3">
                     <StatItem icon={<Trophy className="h-4 w-4" />} label="Candidate" value={data.userName} mono={false} />
                     <StatItem icon={<Trophy className="h-4 w-4" />} label="Total Score" value={`${data.totalScore} / ${data.maxScore}`} />
-                    <StatItem icon={<Clock className="h-4 w-4" />} label="Submitted On" value={formatSubmittedAt(data.submittedAt)} mono={false} />
+                    <StatItem icon={<Clock className="h-4 w-4" />} label="Submitted On" value={<LocalTime iso={data.submittedAt} />} mono={false} />
                 </div>
 
                 <div className="space-y-8">
@@ -419,7 +411,7 @@ export default async function SubmissionDetailPage({
     );
 }
 
-function StatItem({ icon, label, value, mono = true }: { icon: React.ReactNode; label: string; value: string; mono?: boolean }) {
+function StatItem({ icon, label, value, mono = true }: { icon: React.ReactNode; label: string; value: React.ReactNode; mono?: boolean }) {
     return (
         <Card className="h-full border-border bg-card shadow-sm">
             <CardContent className="flex min-h-24 h-full items-center gap-3 px-5 py-">

--- a/client/app/test/[id]/page.tsx
+++ b/client/app/test/[id]/page.tsx
@@ -171,7 +171,7 @@ export default function ContestLanding() {
               </div>
               <div className="flex items-center gap-3">
                 <Clock className="h-5 w-5 text-primary/60" />
-                <span>{details ? new Date(details.startTime).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }) : "-"}</span>
+                <span>{details ? new Date(details.startTime).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', timeZoneName: 'short' }) : "-"}</span>
               </div>
               <div className="flex items-center gap-3">
                 <Hourglass className="h-5 w-5 text-primary/60" />

--- a/client/components/admin/test/leaderboard-table.tsx
+++ b/client/components/admin/test/leaderboard-table.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import React from "react";
-import { format } from "date-fns";
 import {
   Table,
   TableBody,
@@ -29,7 +28,7 @@ export function LeaderboardTable({ data }: LeaderboardTableProps) {
     if (!value) return "N/A";
     const date = new Date(value);
     if (isNaN(date.getTime())) return "N/A";
-    return format(date, "MMM d, yyyy, h:mm a");
+    return date.toLocaleString([], { month: 'short', day: 'numeric', year: 'numeric', hour: '2-digit', minute: '2-digit', timeZoneName: 'short' });
   };
 
   return (

--- a/client/components/admin/test/test-card.tsx
+++ b/client/components/admin/test/test-card.tsx
@@ -14,7 +14,6 @@ import { Button } from "@/components/ui/button";
 import { Clock, Loader2, Trash2 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Test } from "@/types/test";
-import { format } from "date-fns";
 import { getTestStatusBadgeVariant, getTestStatusLabel } from "@/lib/test-status";
 
 import { deleteTestAction } from "@/actions/delete-test";
@@ -52,7 +51,7 @@ export function TestCard({ test }: { test: Test }) {
           <Clock className="h-4 w-4 text-foreground shrink-0" />
           <span className="font-medium">Starts:</span>
           <span className="truncate">
-            {format(new Date(test.startsAt), "MMM d, yyyy, h:mm a")}
+            {new Date(test.startsAt).toLocaleString([], { month: 'short', day: 'numeric', year: 'numeric', hour: '2-digit', minute: '2-digit', timeZoneName: 'short' })}
           </span>
         </div>
 

--- a/client/components/admin/test/test-detail/test-card.tsx
+++ b/client/components/admin/test/test-detail/test-card.tsx
@@ -3,7 +3,6 @@
 import React from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Clock, FileText, Calendar } from "lucide-react";
-import { format } from "date-fns";
 import { Test } from "@/types/test";
 
 interface TestInformationCardProps {
@@ -43,7 +42,7 @@ export function TestInformationCard({ test }: TestInformationCardProps) {
           <div className="flex items-center gap-2 text-foreground">
             <Calendar className="h-4 w-4 text-primary/50" />
             <span className="font-semibold text-sm sm:text-base">
-              {format(new Date(test.startsAt), "MMM d, yyyy, h:mm a")}
+              {new Date(test.startsAt).toLocaleString([], { month: 'short', day: 'numeric', year: 'numeric', hour: '2-digit', minute: '2-digit', timeZoneName: 'short' })}
             </span>
           </div>
         </div>

--- a/client/components/admin/test/test-form/index.tsx
+++ b/client/components/admin/test/test-form/index.tsx
@@ -34,6 +34,7 @@ function getDefaultSchedule() {
   return {
     startsAt: start.toISOString(),
     duration: formatTimeForDisplay(end),
+    endsAt: end.toISOString(),
   };
 }
 
@@ -47,6 +48,7 @@ export default function TestForm({ testData, availableQuestions = [] }: { testDa
       description: "",
       startsAt: defaultSchedule.startsAt,
       duration: defaultSchedule.duration,
+      endsAt: defaultSchedule.endsAt,
       status: "waiting",
       problems: [],
       rules: [],

--- a/client/components/admin/test/test-form/info-card.tsx
+++ b/client/components/admin/test/test-form/info-card.tsx
@@ -27,7 +27,7 @@ import {
   FormControl,
   FormMessage,
 } from "@/components/ui/form";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 function formatTimeForDisplay(hours: number, minutes: number) {
   const period = hours >= 12 ? "PM" : "AM";
@@ -70,9 +70,13 @@ export default function TestBasicCard() {
   const { control, setValue, watch } = useFormContext();
 
   const startsAt = watch("startsAt");
+  const duration = watch("duration");
+  const endsAt = watch("endsAt");
   const [open, setOpen] = useState(false);
   const [date, setDate] = useState<Date | undefined>(undefined);
   const [time, setTime] = useState("12:00 AM");
+  const endsAtInitialized = useRef(false);
+  const userTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
 
   useEffect(() => {
     if (startsAt) {
@@ -98,6 +102,32 @@ export default function TestBasicCard() {
       setValue("startsAt", updated.toISOString());
     }
   }, [date, time, setValue]);
+
+  // On edit: initialize the "Ends At" display from the stored UTC endsAt
+  useEffect(() => {
+    if (!endsAtInitialized.current && endsAt) {
+      endsAtInitialized.current = true;
+      const parsed = new Date(endsAt);
+      if (!isNaN(parsed.getTime())) {
+        setValue("duration", formatTimeForInput(parsed));
+      }
+    }
+  }, [endsAt, setValue]);
+
+  // Recompute endsAt (UTC ISO) whenever the end time input or start date changes
+  useEffect(() => {
+    if (date && duration) {
+      endsAtInitialized.current = true;
+      const parsedTime = parseTimeInput(duration);
+      if (!parsedTime) return;
+      const endDate = new Date(date);
+      endDate.setHours(parsedTime.hours, parsedTime.minutes, 0, 0);
+      if (startsAt && endDate <= new Date(startsAt)) {
+        endDate.setDate(endDate.getDate() + 1);
+      }
+      setValue("endsAt", endDate.toISOString());
+    }
+  }, [date, duration, startsAt, setValue]);
 
   return (
     <Card>
@@ -139,6 +169,9 @@ export default function TestBasicCard() {
           )}
         />
 
+        <p className="text-xs text-muted-foreground">
+          All times are in your local timezone: <span className="font-medium">{userTimezone}</span>
+        </p>
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
           <FormField
             control={control}
@@ -200,10 +233,15 @@ export default function TestBasicCard() {
             </div>
           </div>
         </div>
-        {/* Hidden status field to ensure it is passed */}
+        {/* Hidden fields to ensure computed values are passed */}
         <FormField
           control={control}
           name="status"
+          render={({ field }) => <input type="hidden" {...field} />}
+        />
+        <FormField
+          control={control}
+          name="endsAt"
           render={({ field }) => <input type="hidden" {...field} />}
         />
       </CardContent>

--- a/client/components/ui/local-time.tsx
+++ b/client/components/ui/local-time.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+interface LocalTimeProps {
+  iso: string;
+  fallback?: string;
+}
+
+export function LocalTime({ iso, fallback = "Unknown" }: LocalTimeProps) {
+  const date = new Date(iso);
+  if (isNaN(date.getTime())) return <>{fallback}</>;
+  return (
+    <>
+      {date.toLocaleString([], {
+        month: "short",
+        day: "numeric",
+        year: "numeric",
+        hour: "2-digit",
+        minute: "2-digit",
+        timeZoneName: "short",
+      })}
+    </>
+  );
+}

--- a/client/types/test/test.input.ts
+++ b/client/types/test/test.input.ts
@@ -17,6 +17,7 @@ export const testSchema = z.object({
       "End time must be in HH:MM AM/PM format",
     ),
   startsAt: z.iso.datetime(),
+  endsAt: z.iso.datetime(),
   problems: z.array(z.string()),
   rules: z.array(z.string()).default([]),
 });

--- a/client/types/test/test.types.ts
+++ b/client/types/test/test.types.ts
@@ -15,6 +15,7 @@ export interface Test {
   duration: string;
   totalQuestions: number;
   startsAt: string;
+  endsAt?: string;
   status: "waiting" | "ongoing" | "completed";
   participantsInProgress: number;
   participantsCompleted: number;


### PR DESCRIPTION
## Summary

- **Root cause fixed**: The \"Ends At\" time was parsed via `setHours()` inside a Next.js Server Action (which runs in UTC), so an admin in IST entering \"01:30 PM\" would store `13:30 UTC` instead of `08:00 UTC` (the correct equivalent)
- **End time now computed in the browser**: `info-card.tsx` derives `endsAt` as a UTC ISO string using the browser's local timezone, consistent with how `startsAt` was already handled; the server action receives two UTC ISO strings and does no timezone math
- **Edit form fixed**: When editing a contest, the stored UTC `endTime` is converted back to the admin's local time display via the browser's `Intl` API, not the server's clock
- **All time displays updated**: Every timestamp across the app now uses `toLocaleString` with `timeZoneName: 'short'` so each viewer sees times in their own local timezone with the abbreviation (e.g. \"10:00 AM IST\" for India, \"4:30 AM UTC\" for a UTC viewer)
- **New `<LocalTime>` client component**: Used in server-rendered pages (result, submissions) where timezone conversion must happen on the client after hydration
- **Timezone label in admin form**: Shows the admin's detected timezone (e.g. `Asia/Kolkata`) so they know how their inputs are interpreted

## Test plan

- [ ] Create a new contest as admin — verify start/end times stored in MongoDB are correct UTC equivalents of the local input
- [ ] Edit an existing contest — verify \"Ends At\" field shows the correct local time (not UTC)
- [ ] View the test landing page from a different timezone (DevTools → Sensors → Location) — verify times convert correctly with timezone abbreviation
- [ ] Check admin test list, test detail card, leaderboard, and submissions pages all show local time with abbreviation