### PR TITLE
feat: add test case explanations and LeetCode-style examples display

### DIFF
--- a/client/actions/save-question.ts
+++ b/client/actions/save-question.ts
@@ -22,7 +22,7 @@ export async function saveQuestion(_prevState: Record<string, unknown>, data: Qu
       // Coding specific
       inputFormat: validatedData.type === 'coding' ? validatedData.inputFormat : undefined,
       outputFormat: validatedData.type === 'coding' ? validatedData.outputFormat : undefined,
-      constraints: validatedData.type === 'coding' ? String(validatedData.constraints) : undefined, // Expecting String
+      constraints: validatedData.type === 'coding' ? validatedData.constraints.join('\n') : undefined, // Expecting String, newline per constraint
       boilerplateCode: validatedData.type === 'coding' ? validatedData.boilerplate : undefined, // Map boilerplate -> boilerplateCode
       functionName: validatedData.type === 'coding' ? validatedData.functionName : undefined,
       inputVariables: validatedData.type === 'coding' ? validatedData.inputVariables : undefined,

--- a/client/app/admin/questions/[type]/[id]/edit/page.tsx
+++ b/client/app/admin/questions/[type]/[id]/edit/page.tsx
@@ -59,7 +59,9 @@ export default async function EditQuestionPage({
     outputFormat: data.outputFormat || "",
     boilerplate: data.boilerplateCode || {},
     constraints: typeof data.constraints === 'string'
-      ? data.constraints.split(',').map((s: string) => s.trim()).filter(Boolean)
+      ? (data.constraints.includes('\n')
+          ? data.constraints.split('\n').map((s: string) => s.trim()).filter(Boolean)
+          : data.constraints.split(',').map((s: string) => s.trim()).filter(Boolean)) // legacy comma-joined fallback
       : (Array.isArray(data.constraints) ? data.constraints : [""]),
     functionName: data.functionName || "",
     inputVariables: data.inputVariables || [],

--- a/client/components/admin/question/coding/test-case-card.tsx
+++ b/client/components/admin/question/coding/test-case-card.tsx
@@ -72,8 +72,8 @@ export default function TestCaseCard() {
 
     const handleDownloadTemplate = () => {
         if (!inputVariables || inputVariables.length === 0) return;
-        const headers = ["isVisible", "output", ...inputVariables.map((v: {variable: string}) => v.variable)];
-        const exampleRow = ["FALSE", "Expected Output", ...inputVariables.map((v: {variable: string}) => `Value for ${v.variable}`)];
+        const headers = ["isVisible", "output", "explanation", ...inputVariables.map((v: {variable: string}) => v.variable)];
+        const exampleRow = ["FALSE", "Expected Output", "Optional explanation", ...inputVariables.map((v: {variable: string}) => `Value for ${v.variable}`)];
         const csvContent = headers.join(",") + "\n" + exampleRow.join(",");
         
         const blob = new Blob([csvContent], { type: "text/csv" });
@@ -161,6 +161,7 @@ export default function TestCaseCard() {
                 newTestCases.push({
                     isVisible: rowData['isVisible']?.toUpperCase() === 'TRUE',
                     output: rowData['output'] || '',
+                    explanation: rowData['explanation'] || '',
                     input: inputData
                 });
             }
@@ -352,7 +353,7 @@ export default function TestCaseCard() {
                                     type="button"
                                     variant="outline"
                                     size="sm"
-                                    onClick={() => appendTestCase({ input: {}, output: "", isVisible: false })}
+                                    onClick={() => appendTestCase({ input: {}, output: "", explanation: "", isVisible: false })}
                                     disabled={isVariableInvalid}
                                 >
                                     <Plus className="h-4 w-4 mr-2" />
@@ -485,6 +486,27 @@ export default function TestCaseCard() {
                                                     )}
                                                 />
                                             </div>
+                                        </div>
+
+                                        <div className="space-y-3 p-3 bg-background/50 rounded-md border">
+                                            <span className="text-xs font-semibold uppercase text-muted-foreground">Explanation (optional)</span>
+                                            <FormField
+                                                control={control}
+                                                name={`testCases.${index}.explanation`}
+                                                render={({ field }) => (
+                                                    <FormItem>
+                                                        <FormControl>
+                                                            <Textarea
+                                                                {...field}
+                                                                value={field.value ?? ""}
+                                                                placeholder="Shown to users alongside this example, e.g. why the output is what it is"
+                                                                className="min-h-17.5 resize-none text-sm"
+                                                            />
+                                                        </FormControl>
+                                                        <FormMessage />
+                                                    </FormItem>
+                                                )}
+                                            />
                                         </div>
                                     </div>
                                 ))}

--- a/client/components/admin/question/coding/test-case-card.tsx
+++ b/client/components/admin/question/coding/test-case-card.tsx
@@ -150,7 +150,7 @@ export default function TestCaseCard() {
                     rowData[h] = values[idx] || '';
                 });
 
-                const inputData: Record<string, any> = {};
+                const inputData: Record<string, string | string[]> = {};
                 inputVariables.forEach((v: {variable: string; type: string}) => {
                     const raw = rowData[v.variable] || '';
                     inputData[v.variable] = v.type.includes("_array")

--- a/client/components/attempt/code/description.tsx
+++ b/client/components/attempt/code/description.tsx
@@ -54,10 +54,52 @@ export default function DescriptionPanel({
           </div>
 
           {problem.constraints && (
-            <div>
-              <Label className="text-muted-foreground">Constraints</Label>
-              <p className="whitespace-pre-wrap">{problem.constraints}</p>
-            </div>
+            <>
+              <Separator />
+              <div>
+                <Label className="text-muted-foreground pb-2 block">Constraints</Label>
+                <ul className="list-disc pl-5">
+                  {problem.constraints.split(/\n|,/).map(s => s.trim()).filter(Boolean).map((constraint, index) => (
+                    <li key={index} className="whitespace-pre-wrap">{constraint}</li>
+                  ))}
+                </ul>
+              </div>
+            </>
+          )}
+
+          {problem.examples && problem.examples.length > 0 && (
+            <>
+              <Separator />
+              <div className="space-y-4">
+                <Label className="text-muted-foreground">Examples</Label>
+                {problem.examples.map((example, index) => (
+                  <React.Fragment key={index}>
+                    {index > 0 && <Separator />}
+                    <div className="space-y-2 text-sm">
+                      <p className="font-medium">Example {index + 1}:</p>
+                      <div>
+                        <span className="text-muted-foreground block">Input:</span>
+                        <code className="rounded-md border bg-muted/30 px-2 py-1 font-mono whitespace-pre-wrap inline-block mt-1">
+                          {example.input}
+                        </code>
+                      </div>
+                      <div>
+                        <span className="text-muted-foreground block">Output:</span>
+                        <code className="rounded-md border bg-muted/30 px-2 py-1 font-mono whitespace-pre-wrap inline-block mt-1">
+                          {example.output}
+                        </code>
+                      </div>
+                      {example.explanation && (
+                        <div>
+                          <span className="text-muted-foreground block">Explanation:</span>
+                          <p className="whitespace-pre-wrap mt-1">{example.explanation}</p>
+                        </div>
+                      )}
+                    </div>
+                  </React.Fragment>
+                ))}
+              </div>
+            </>
           )}
         </div>
       </ScrollArea>

--- a/client/public/templates/questions_import_example.json
+++ b/client/public/templates/questions_import_example.json
@@ -25,7 +25,7 @@
         { "variable": "target", "type": "int" }
       ],
       "testcases": [
-        { "input": "4 9\n2 7 11 15", "output": "0 1", "isVisible": true }
+        { "input": "4 9\n2 7 11 15", "output": "0 1", "isVisible": true, "explanation": "nums[0] + nums[1] = 2 + 7 = 9, so the answer is [0, 1]." }
       ]
     }
   ],

--- a/client/types/problem/problem.input.ts
+++ b/client/types/problem/problem.input.ts
@@ -47,6 +47,7 @@ const codingSchema = z.object({
       z.object({
         input: z.any(),
         output: z.string().min(1, "Expected output is required"),
+        explanation: z.string().optional(),
         isVisible: z.boolean().default(false),
       })
     )

--- a/client/types/problem/problem.types.ts
+++ b/client/types/problem/problem.types.ts
@@ -23,6 +23,11 @@ export interface CodingProblem extends BaseProblem {
     python?: string;
     javascript?: string;
   };
+  examples?: {
+    input: string;
+    output: string;
+    explanation?: string;
+  }[];
 }
 
 export interface MCQProblem extends BaseProblem {

--- a/docs/bulk-question-generation-prompt.md
+++ b/docs/bulk-question-generation-prompt.md
@@ -1,0 +1,485 @@
+# Bulk Question Generation — Prompt Template
+
+A self-contained, reusable prompt for generating a bulk-import question set.
+Fill in the `{{ }}` placeholders and paste the whole "Prompt" section below
+into any AI chat tool. The resulting JSON can be pasted directly into the
+platform's bulk question import.
+
+---
+
+## Prompt
+
+You are generating a bulk-import question set for a coding assessment
+platform. Your output must be a single JSON document that validates against
+the schema described below. Follow every rule exactly — the file will be
+parsed and inserted into a database without manual correction.
+
+### 1. Output contract
+
+Return **only** valid JSON — no markdown fences, no comments, no trailing
+commas, no prose before or after. Top-level shape:
+
+```json
+{
+  "questions": [ /* array of question objects, coding and/or mcq, see §3 */ ],
+  "meta": {
+    "description": "{{one-line description of this batch}}"
+  }
+}
+```
+
+### 2. What to generate
+
+- Topic: **{{topic, e.g. "arrays and hashing"}}**
+- Count: **{{N}} questions**, distributed LeetCode-style across difficulty:
+  roughly a third Easy, a third Medium, a third Hard (adjust ratio if
+  told otherwise).
+- Question type: **{{"coding", "mcq", or a mix}}**
+- Each question must be original, in the spirit of LeetCode — a clear
+  title, an unambiguous problem/prompt, and a single well-defined correct
+  answer.
+
+### 3. Question object shapes
+
+Two question types share one array. Each object has a `type` field of
+either `"coding"` or `"mcq"`, with the fields below.
+
+**Coding:**
+
+```json
+{
+  "type": "coding",
+  "title": "string",
+  "description": "string — the full problem statement",
+  "marks": 10,
+  "difficulty": "Easy" | "Medium" | "Hard",
+  "constraints": "string — one constraint per line, no numbering",
+  "inputFormat": "string — describes the function's parameters, see §6",
+  "outputFormat": "string — describes what's printed to stdout, see §6",
+  "functionName": "string — camelCase, e.g. twoSum",
+  "inputVariables": [
+    { "variable": "string", "type": "int" | "float" | "char" | "string" | "int_array" | "float_array" | "string_array" }
+  ],
+  "testcases": [
+    { "input": "string", "output": "string", "isVisible": true, "explanation": "string (optional, required when isVisible is true)" }
+  ]
+}
+```
+
+**MCQ:**
+
+```json
+{
+  "type": "mcq",
+  "title": "string",
+  "description": "string — the question prompt",
+  "marks": 10,
+  "difficulty": "Easy" | "Medium" | "Hard",
+  "questionType": "Single Correct" | "Multiple Correct",
+  "options": ["string", "string", "string", "string"],
+  "correctAnswer": "string — must exactly match one entry in options (or a comma-separated list of them, for Multiple Correct)"
+}
+```
+
+`marks` convention: Easy = 10, Medium = 20, Hard = 30 (override if told
+otherwise).
+
+### 4. Worked examples
+
+<details open>
+<summary>Example coding question</summary>
+
+```json
+{
+  "type": "coding",
+  "title": "Two Sum",
+  "description": "Given an array of integers nums and an integer target, return the indices of the two numbers that add up to target. You may assume each input has exactly one solution, and the same element may not be used twice.",
+  "marks": 10,
+  "difficulty": "Easy",
+  "constraints": "2 <= nums.length <= 10^4\n-10^9 <= nums[i] <= 10^9\nOnly one valid answer exists.",
+  "inputFormat": "The function receives nums (a list of integers) and target (an integer).",
+  "outputFormat": "Return two space-separated integers: the indices of the two numbers that add up to target, in ascending order.",
+  "functionName": "twoSum",
+  "inputVariables": [
+    { "variable": "nums", "type": "int_array" },
+    { "variable": "target", "type": "int" }
+  ],
+  "testcases": [
+    { "input": "4 2 7 11 15 9", "output": "0 1", "isVisible": true, "explanation": "nums[0] + nums[1] = 2 + 7 = 9, so the answer is [0, 1]." },
+    { "input": "3 3 2 4 6", "output": "1 2", "isVisible": true, "explanation": "nums[1] + nums[2] = 2 + 4 = 6, so the answer is [1, 2]." },
+    { "input": "2 3 3 6", "output": "0 1", "isVisible": true, "explanation": "The same value 3 appears twice at different indices, and they sum to target." },
+    { "input": "2 0 0 0", "output": "0 1", "isVisible": false },
+    { "input": "2 -3 4 1", "output": "0 1", "isVisible": false }
+  ]
+}
+```
+
+</details>
+
+<details open>
+<summary>Example MCQ question</summary>
+
+```json
+{
+  "type": "mcq",
+  "title": "Time complexity of binary search",
+  "description": "What is the time complexity of binary search on a sorted array of n elements?",
+  "marks": 10,
+  "difficulty": "Easy",
+  "questionType": "Single Correct",
+  "options": ["O(n)", "O(log n)", "O(n log n)", "O(1)"],
+  "correctAnswer": "O(log n)"
+}
+```
+
+</details>
+
+### 5. Test case requirements for coding questions — read carefully
+
+Each coding question needs **exactly 13 test cases**:
+
+- **10 hidden** (`isVisible: false`) — used for grading. Together they must
+  exercise correctness *and* edge cases: minimum-size input, maximum-size
+  input allowed by the stated constraints, duplicate values, negative
+  numbers (if applicable to the domain), zero/empty values where legal, and
+  at least one case that would trip up a naive/incorrect solution. Omit the
+  `explanation` field entirely for these.
+- **3 visible** (`isVisible: true`) — shown to the user as worked examples
+  before they run any code. Each **must** include a non-empty
+  `explanation` that walks through why the output is correct for that
+  specific input, LeetCode-style.
+
+Every test case, hidden or visible, must be **unambiguous**: for the given
+input there is exactly one correct output, fully determined by the problem
+statement and constraints (no "any valid answer accepted" ambiguity unless
+the statement explicitly defines a tie-breaking rule and the expected
+output follows it).
+
+### 6. `input` / `output` encoding for test cases — this is not free text
+
+The grading harness does not pass structured JSON to the judge; it flattens
+each test case into raw **stdin**, and compares raw **stdout**. Both fields
+must be written as flat, whitespace-separated strings, positionally
+matching `inputVariables` in the order they're declared:
+
+- Scalar types (`int`, `float`, `char`, `string`) → the value itself as a
+  token (e.g. `9`).
+- Array types (`int_array`, `float_array`, `string_array`) → the array's
+  **length**, followed by its elements, all space-separated (e.g. the array
+  `[2, 7, 11, 15]` becomes `4 2 7 11 15`).
+- Multiple variables are concatenated left-to-right, space-separated.
+
+`output` follows the same flattening rule for whatever the program prints.
+
+This flat stdin/stdout encoding is purely an implementation detail of the
+grading harness — it is **not** what the learner sees or writes code for.
+The harness auto-generates a function stub matching `functionName` and
+`inputVariables`, reads stdin, splits it back into typed parameters per the
+rule above, and calls the learner's function directly — e.g. for
+`functionName: "twoSum"` with `inputVariables = [nums: int_array, target:
+int]`, the learner is handed something like:
+
+```python
+def twoSum(nums, target):
+    # write your code here
+```
+
+The harness then prints whatever the function **returns**. So the two
+human-facing format fields describe two different halves of this pipeline:
+
+- **`inputFormat`** describes the **function's parameters** — their names,
+  types, and meaning — matching `inputVariables`, e.g. "The function
+  receives `nums` (a list of integers) and `target` (an integer)." Do
+  **not** describe it as a stdin-parsing task (e.g. "First line contains
+  n and target...") — the learner never reads stdin themselves.
+- **`outputFormat`** describes **what ends up on stdout** (the harness
+  prints the function's return value for you), e.g. "Return two
+  space-separated integers: the indices of the two numbers that add up to
+  target." Be explicit that it's printed as space-separated values, not
+  returned as a structured object — that's what the stdout comparison in
+  this section actually checks against `output`.
+
+### 7. Supported data types
+
+Only these `inputVariables[].type` values are valid for coding questions:
+
+| type | meaning |
+|---|---|
+| `int` | signed integer |
+| `float` | floating point number |
+| `char` | single character |
+| `string` | text token (no embedded whitespace) |
+| `int_array` | array of integers, length-prefixed per §6 |
+| `float_array` | array of floats, length-prefixed per §6 |
+| `string_array` | array of string tokens, length-prefixed per §6 |
+
+### 8. Supported languages
+
+Coding submissions are judged in **C, Java, and Python** only. Starter code
+for all three is generated automatically from `functionName` and
+`inputVariables` — do not include language-specific boilerplate in the
+output unless explicitly asked to.
+
+### 9. Style guidance
+
+- Titles and phrasing should read like real LeetCode problems — concise,
+  no filler, precise constraints using standard notation (`1 <= n <= 10^4`).
+- Vary problem domains within the requested topic so the set isn't
+  repetitive (e.g. don't generate 10 variations of the same array-sum
+  problem).
+- Do not reuse example values between the 3 visible test cases in a single
+  coding question — each should use different input values so they
+  collectively illustrate different behavior, not just the happy path
+  three times.
+- For MCQ questions, distractor options must be plausible (not obviously
+  wrong) and only one option (or the stated set, for Multiple Correct) may
+  be correct.
+
+---
+
+## Example: the prompt fully filled in
+
+Only §1 and §2 above contain placeholders — everything else stays as-is.
+Here's what the whole thing looks like once filled in for a request of "12
+easy-to-hard coding questions on arrays and hashing." This is the literal
+text you'd paste into an AI chat tool.
+
+<details>
+<summary>Show the fully filled-in prompt</summary>
+
+`````text
+You are generating a bulk-import question set for a coding assessment
+platform. Your output must be a single JSON document that validates against
+the schema described below. Follow every rule exactly — the file will be
+parsed and inserted into a database without manual correction.
+
+### 1. Output contract
+
+Return **only** valid JSON — no markdown fences, no comments, no trailing
+commas, no prose before or after. Top-level shape:
+
+```json
+{
+  "questions": [ /* array of question objects, coding and/or mcq, see §3 */ ],
+  "meta": {
+    "description": "12 LeetCode-style coding questions on arrays and hashing, Easy to Hard"
+  }
+}
+```
+
+### 2. What to generate
+
+- Topic: **arrays and hashing**
+- Count: **12 questions**, distributed LeetCode-style across difficulty:
+  roughly a third Easy, a third Medium, a third Hard (adjust ratio if
+  told otherwise).
+- Question type: **coding only**
+- Each question must be original, in the spirit of LeetCode — a clear
+  title, an unambiguous problem/prompt, and a single well-defined correct
+  answer.
+
+### 3. Question object shapes
+
+Two question types share one array. Each object has a `type` field of
+either `"coding"` or `"mcq"`, with the fields below.
+
+**Coding:**
+
+```json
+{
+  "type": "coding",
+  "title": "string",
+  "description": "string — the full problem statement",
+  "marks": 10,
+  "difficulty": "Easy" | "Medium" | "Hard",
+  "constraints": "string — one constraint per line, no numbering",
+  "inputFormat": "string — describes the function's parameters, see §6",
+  "outputFormat": "string — describes what's printed to stdout, see §6",
+  "functionName": "string — camelCase, e.g. twoSum",
+  "inputVariables": [
+    { "variable": "string", "type": "int" | "float" | "char" | "string" | "int_array" | "float_array" | "string_array" }
+  ],
+  "testcases": [
+    { "input": "string", "output": "string", "isVisible": true, "explanation": "string (optional, required when isVisible is true)" }
+  ]
+}
+```
+
+**MCQ:**
+
+```json
+{
+  "type": "mcq",
+  "title": "string",
+  "description": "string — the question prompt",
+  "marks": 10,
+  "difficulty": "Easy" | "Medium" | "Hard",
+  "questionType": "Single Correct" | "Multiple Correct",
+  "options": ["string", "string", "string", "string"],
+  "correctAnswer": "string — must exactly match one entry in options (or a comma-separated list of them, for Multiple Correct)"
+}
+```
+
+`marks` convention: Easy = 10, Medium = 20, Hard = 30 (override if told
+otherwise).
+
+### 4. Worked examples
+
+Example coding question:
+
+```json
+{
+  "type": "coding",
+  "title": "Two Sum",
+  "description": "Given an array of integers nums and an integer target, return the indices of the two numbers that add up to target. You may assume each input has exactly one solution, and the same element may not be used twice.",
+  "marks": 10,
+  "difficulty": "Easy",
+  "constraints": "2 <= nums.length <= 10^4\n-10^9 <= nums[i] <= 10^9\nOnly one valid answer exists.",
+  "inputFormat": "The function receives nums (a list of integers) and target (an integer).",
+  "outputFormat": "Return two space-separated integers: the indices of the two numbers that add up to target, in ascending order.",
+  "functionName": "twoSum",
+  "inputVariables": [
+    { "variable": "nums", "type": "int_array" },
+    { "variable": "target", "type": "int" }
+  ],
+  "testcases": [
+    { "input": "4 2 7 11 15 9", "output": "0 1", "isVisible": true, "explanation": "nums[0] + nums[1] = 2 + 7 = 9, so the answer is [0, 1]." },
+    { "input": "3 3 2 4 6", "output": "1 2", "isVisible": true, "explanation": "nums[1] + nums[2] = 2 + 4 = 6, so the answer is [1, 2]." },
+    { "input": "2 3 3 6", "output": "0 1", "isVisible": true, "explanation": "The same value 3 appears twice at different indices, and they sum to target." },
+    { "input": "2 0 0 0", "output": "0 1", "isVisible": false },
+    { "input": "2 -3 4 1", "output": "0 1", "isVisible": false }
+  ]
+}
+```
+
+Example MCQ question:
+
+```json
+{
+  "type": "mcq",
+  "title": "Time complexity of binary search",
+  "description": "What is the time complexity of binary search on a sorted array of n elements?",
+  "marks": 10,
+  "difficulty": "Easy",
+  "questionType": "Single Correct",
+  "options": ["O(n)", "O(log n)", "O(n log n)", "O(1)"],
+  "correctAnswer": "O(log n)"
+}
+```
+
+(Since this batch is coding-only, omit MCQ objects from the actual output —
+this example is included only to show the shape.)
+
+### 5. Test case requirements for coding questions — read carefully
+
+Each coding question needs **exactly 13 test cases**:
+
+- **10 hidden** (`isVisible: false`) — used for grading. Together they must
+  exercise correctness *and* edge cases: minimum-size input, maximum-size
+  input allowed by the stated constraints, duplicate values, negative
+  numbers (if applicable to the domain), zero/empty values where legal, and
+  at least one case that would trip up a naive/incorrect solution. Omit the
+  `explanation` field entirely for these.
+- **3 visible** (`isVisible: true`) — shown to the user as worked examples
+  before they run any code. Each **must** include a non-empty
+  `explanation` that walks through why the output is correct for that
+  specific input, LeetCode-style.
+
+Every test case, hidden or visible, must be **unambiguous**: for the given
+input there is exactly one correct output, fully determined by the problem
+statement and constraints (no "any valid answer accepted" ambiguity unless
+the statement explicitly defines a tie-breaking rule and the expected
+output follows it).
+
+### 6. `input` / `output` encoding for test cases — this is not free text
+
+The grading harness does not pass structured JSON to the judge; it flattens
+each test case into raw **stdin**, and compares raw **stdout**. Both fields
+must be written as flat, whitespace-separated strings, positionally
+matching `inputVariables` in the order they're declared:
+
+- Scalar types (`int`, `float`, `char`, `string`) → the value itself as a
+  token (e.g. `9`).
+- Array types (`int_array`, `float_array`, `string_array`) → the array's
+  **length**, followed by its elements, all space-separated (e.g. the array
+  `[2, 7, 11, 15]` becomes `4 2 7 11 15`).
+- Multiple variables are concatenated left-to-right, space-separated.
+
+`output` follows the same flattening rule for whatever the program prints.
+
+This flat stdin/stdout encoding is purely an implementation detail of the
+grading harness — it is **not** what the learner sees or writes code for.
+The harness auto-generates a function stub matching `functionName` and
+`inputVariables`, reads stdin, splits it back into typed parameters per the
+rule above, and calls the learner's function directly — e.g. for
+`functionName: "twoSum"` with `inputVariables = [nums: int_array, target:
+int]`, the learner is handed something like:
+
+```python
+def twoSum(nums, target):
+    # write your code here
+```
+
+The harness then prints whatever the function **returns**. So the two
+human-facing format fields describe two different halves of this pipeline:
+
+- **`inputFormat`** describes the **function's parameters** — their names,
+  types, and meaning — matching `inputVariables`, e.g. "The function
+  receives `nums` (a list of integers) and `target` (an integer)." Do
+  **not** describe it as a stdin-parsing task (e.g. "First line contains
+  n and target...") — the learner never reads stdin themselves.
+- **`outputFormat`** describes **what ends up on stdout** (the harness
+  prints the function's return value for you), e.g. "Return two
+  space-separated integers: the indices of the two numbers that add up to
+  target." Be explicit that it's printed as space-separated values, not
+  returned as a structured object — that's what the stdout comparison in
+  this section actually checks against `output`.
+
+### 7. Supported data types
+
+Only these `inputVariables[].type` values are valid for coding questions:
+
+| type | meaning |
+|---|---|
+| `int` | signed integer |
+| `float` | floating point number |
+| `char` | single character |
+| `string` | text token (no embedded whitespace) |
+| `int_array` | array of integers, length-prefixed per §6 |
+| `float_array` | array of floats, length-prefixed per §6 |
+| `string_array` | array of string tokens, length-prefixed per §6 |
+
+### 8. Supported languages
+
+Coding submissions are judged in **C, Java, and Python** only. Starter code
+for all three is generated automatically from `functionName` and
+`inputVariables` — do not include language-specific boilerplate in the
+output unless explicitly asked to.
+
+### 9. Style guidance
+
+- Titles and phrasing should read like real LeetCode problems — concise,
+  no filler, precise constraints using standard notation (`1 <= n <= 10^4`).
+- Vary problem domains within the requested topic so the set isn't
+  repetitive (e.g. don't generate 10 variations of the same array-sum
+  problem).
+- Do not reuse example values between the 3 visible test cases in a single
+  coding question — each should use different input values so they
+  collectively illustrate different behavior, not just the happy path
+  three times.
+- For MCQ questions, distractor options must be plausible (not obviously
+  wrong) and only one option (or the stated set, for Multiple Correct) may
+  be correct.
+`````
+
+</details>
+
+---
+
+## Notes for whoever fills this in
+
+- Adjust §2's topic/count/type placeholders per request; everything else in
+  the prompt is meant to stay fixed so output is consistently importable.
+- If the target platform's schema differs from §3 (field names, extra
+  required fields, different difficulty labels, etc.), update §3, the
+  examples in §4, and the type table in §7 to match before reuse.

--- a/server/controllers/contestCon.js
+++ b/server/controllers/contestCon.js
@@ -3,6 +3,7 @@ const User = require('../models/User');
 const Question = require('../models/Question');
 const { languageMap } = require('../utils/languageMap');
 const { getJudge } = require('@pomelo/code-gen');
+const { formatTestCaseInput } = require('../utils/formatTestCaseInput');
 
 // @desc    Validate 6-digit Join ID (OTP)
 // @route   POST /api/contest/validate
@@ -183,7 +184,15 @@ const getContestData = async (req, res, next) => {
                     marks: q.marks,
                     savedAnswer: answerMap[q._id.toString()] ? answerMap[q._id.toString()].answer : undefined,
                     savedCode: answerMap[q._id.toString()] ? answerMap[q._id.toString()].code : undefined,
-                    savedLanguage: answerMap[q._id.toString()] ? answerMap[q._id.toString()].language : undefined
+                    savedLanguage: answerMap[q._id.toString()] ? answerMap[q._id.toString()].language : undefined,
+                    examples: (q.testcases || [])
+                        .filter(tc => tc.isVisible)
+                        .slice(0, 3)
+                        .map(tc => ({
+                            input: formatTestCaseInput(tc.input, q.inputVariables),
+                            output: tc.output,
+                            explanation: tc.explanation || undefined,
+                        })),
                 }))
             }
         });

--- a/server/models/Question.js
+++ b/server/models/Question.js
@@ -42,6 +42,7 @@ const questionSchema = new mongoose.Schema({
   testcases: [{
     input: String,
     output: String,
+    explanation: String,
     isVisible: {
       type: Boolean,
       default: false

--- a/server/utils/formatTestCaseInput.js
+++ b/server/utils/formatTestCaseInput.js
@@ -1,0 +1,55 @@
+// Formats a test case's input for display as a LeetCode-style example
+// (e.g. "nums = [2, 7, 11, 15], target = 9"), independent of the
+// judge0-stdin formatting used at judge time (see submitCon.js).
+
+const formatValue = (value) => {
+  if (Array.isArray(value)) {
+    return `[${value.join(', ')}]`;
+  }
+  return String(value ?? '');
+};
+
+// Legacy/bulk-imported test cases may store `input` as a raw stdin-style
+// string (e.g. "4 9\n2 7 11 15") rather than an object keyed by variable
+// name. Best-effort tokenize it against inputVariables, mirroring the
+// client's deserializeInput (client/lib/test-case-utils.ts).
+const parseStringInput = (input, inputVariables) => {
+  const tokens = input.trim().split(/\s+/);
+  const result = {};
+  let p = 0;
+
+  for (const v of inputVariables) {
+    if (p >= tokens.length) break;
+
+    if (v.type && v.type.includes('_array')) {
+      const size = parseInt(tokens[p++], 10);
+      const elements = [];
+      if (!isNaN(size)) {
+        for (let i = 0; i < size && p < tokens.length; i++) {
+          elements.push(tokens[p++]);
+        }
+      }
+      result[v.variable] = elements;
+    } else {
+      result[v.variable] = tokens[p++];
+    }
+  }
+
+  return result;
+};
+
+function formatTestCaseInput(input, inputVariables = []) {
+  if (!inputVariables || inputVariables.length === 0) {
+    return typeof input === 'string' ? input : JSON.stringify(input);
+  }
+
+  const values = typeof input === 'string'
+    ? parseStringInput(input, inputVariables)
+    : (input || {});
+
+  return inputVariables
+    .map((v) => `${v.variable} = ${formatValue(values[v.variable])}`)
+    .join(', ');
+}
+
+module.exports = { formatTestCaseInput };

--- a/server/utils/questionsIO/validators.js
+++ b/server/utils/questionsIO/validators.js
@@ -29,6 +29,7 @@ const inputVariableSchema = z.object({
 const testCaseSchema = z.object({
   input: z.string().min(1, "Input is required"),
   output: z.string(),
+  explanation: z.string().optional(),
   isVisible: z.boolean().optional().default(false),
 });
 


### PR DESCRIPTION
## Summary
- Added an `explanation` field to coding question test cases (`{ input, output, isVisible, explanation }`), wired through the Mongoose model, both Zod schemas (admin form + bulk import), and a new optional textarea + CSV column in the test case admin UI.
- Fixed `constraints` being saved as a comma-joined string via `Array.prototype.toString()` instead of an actual list — now joined with newlines on save, and the edit-page load path splits on newline (falling back to comma-split for previously-saved data).
- Added a static "Examples" section to the attempt page description panel, shown before Run/Submit — the first 3 `isVisible` test cases per question are now surfaced via `getContestData`, with `input` flattened into a readable `var = value` string (new `formatTestCaseInput` helper) instead of raw judge0 stdin. Explanation is only rendered when present, so hidden or unexplained test cases render cleanly.
- Reworked the description panel layout: a divider between Input/Output Format and Constraints, constraints as a bulleted list, and Input/Output/Explanation in examples each on their own line with the value visually separated from the label.
- Added `docs/bulk-question-generation-prompt.md`, a self-contained, reusable prompt template (with filled-in example) for generating bulk-import JSON question sets — covers the coding/mcq schema shapes, the stdin/stdout test case encoding, and the function-signature-vs-stdout distinction so generated test cases are actually valid against the import pipeline.

## Test plan
- [x] `tsc --noEmit` on `client` passes (aside from a pre-existing unrelated `globals.css` type error)
- [x] Server files (`Question.js`, `validators.js`, `contestCon.js`, `formatTestCaseInput.js`) load without syntax errors
- [x] Manually verified `formatTestCaseInput` output for both object-shaped and legacy string-shaped test case input
- [x] Manual UI pass: create a coding question with visible + hidden test cases and explanations, confirm the Examples block renders correctly on the attempt page and Run/Submit is unaffected